### PR TITLE
Implementar suporte ao Correio24Horas

### DIFF
--- a/src/burlesco.user.js
+++ b/src/burlesco.user.js
@@ -289,14 +289,16 @@ document.addEventListener('DOMContentLoaded', function() {
       document.queryselectorall('.content-blocked')
         .foreach(x => x.classlist.remove('content-blocked'))
     `;
-  
+
   else if(/correio24horas\.com\.br/.test(document.location.host))
     // remover tudo relacionado ao paywall e remover limite de altura no div do conteúdo da matéria
+    // verificar se a altura não buga com a mudança de largura da página (layout responsivo, né)
     code=`
       jQuery('[class^=paywall]').remove();
       jQuery('[class$=blocked]').removeClass();
       jQuery('[id^=paywall]').removeClass('hide').removeClass('is-active');
-      jQuery('.noticias-single__content__text').attr('style', '')
+      jQuery('.noticias-single__content__text').attr('style', 'height:auto;');
+      jQuery('[id^=paywall]').remove();
     `;
 
   else if (/nytimes\.com/.test(document.location.host))

--- a/src/burlesco.user.js
+++ b/src/burlesco.user.js
@@ -59,8 +59,6 @@
 // @match        *://*.diariodaregiao.com.br/*
 // @match        *://*.correio24horas.com.br/*
 // @webRequestItem {"selector":"*://correio-static.cworks.cloud/vendor/bower_components/paywall.js/paywall.js*","action":"cancel"}
-// @webRequestItem {"selector":"*://collector.mediator.media/script/*","action":"cancel"}
-// @webRequestItem {"selector":"*://c24h.lvsn.se/*","action":"cancel"}
 // @webRequestItem {"selector":{"include":"*://paywall.folha.uol.com.br/*","exclude":"*://paywall.folha.uol.com.br/status.php"} ,"action":"cancel"}
 // @webRequestItem {"selector":"*://static.folha.uol.com.br/paywall/*","action":"cancel"}
 // @webRequestItem {"selector":"*://ogjs.infoglobo.com.br/*/js/controla-acesso-aux.js","action":"cancel"}

--- a/src/burlesco.user.js
+++ b/src/burlesco.user.js
@@ -57,6 +57,10 @@
 // @match        *://*.haaretz.co.il/*
 // @match        *://*.diarinho.com.br/*
 // @match        *://*.diariodaregiao.com.br/*
+// @match        *://*.correio24horas.com.br/*
+// @webRequestItem {"selector":"*://correio-static.cworks.cloud/vendor/bower_components/paywall.js/paywall.js*","action":"cancel"}
+// @webRequestItem {"selector":"*://collector.mediator.media/script/*","action":"cancel"}
+// @webRequestItem {"selector":"*://c24h.lvsn.se/*","action":"cancel"}
 // @webRequestItem {"selector":{"include":"*://paywall.folha.uol.com.br/*","exclude":"*://paywall.folha.uol.com.br/status.php"} ,"action":"cancel"}
 // @webRequestItem {"selector":"*://static.folha.uol.com.br/paywall/*","action":"cancel"}
 // @webRequestItem {"selector":"*://ogjs.infoglobo.com.br/*/js/controla-acesso-aux.js","action":"cancel"}
@@ -284,6 +288,15 @@ document.addEventListener('DOMContentLoaded', function() {
         .foreach(x => x.remove());
       document.queryselectorall('.content-blocked')
         .foreach(x => x.classlist.remove('content-blocked'))
+    `;
+  
+  else if(/correio24horas\.com\.br/.test(document.location.host))
+    // remover tudo relacionado ao paywall e remover limite de altura no div do conteúdo da matéria
+    code=`
+      jQuery('[class^=paywall]').remove();
+      jQuery('[class$=blocked]').removeClass();
+      jQuery('[id^=paywall]').removeClass('hide').removeClass('is-active');
+      jQuery('.noticias-single__content__text').attr('style', '')
     `;
 
   else if (/nytimes\.com/.test(document.location.host))


### PR DESCRIPTION
Atualizei o userscript pra funcionar contra o paywall do correio24horas.com.br.
O paywall na verdade é um "forçador" de login via redes sociais. 
Inclusive é inútil contra o "Modo Leitura" do Firefox - é possível ler as notícias usando esse modo.

Não sei o comportamento para a seção de assinantes do Correio24Horas, pois não testei essa modalidade se serviço pago.
O paywall é facilmente enganável, pelo visto. Basta chamar a variável "paywall" no Console.

Me parece também que o site usa Wordpress e um plugin de rastreio famoso, o "Mautic". Basta [acessar aqui](https://c24h.lvsn.se/s/login).