### PR TITLE
fixes ft.com [Closes #12]

### DIFF
--- a/src/burlesco.user.js
+++ b/src/burlesco.user.js
@@ -208,17 +208,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   else if (/ft\.com/.test(document.location.host)
-      && document.querySelector('.barrier-banner')) {
-
-    eraseAllCookies();
-
-    document.cookie = '';
-    localStorage.clear();
-    sessionStorage.clear();
-    indexedDB.deleteDatabase('next-flags');
-    indexedDB.deleteDatabase('next:ads');
-
-    document.querySelector('.o-cookie-message').remove();
+    && document.querySelector('.barrier-banner')) {
 
     GM_xmlhttpRequest({
       method: 'GET',
@@ -228,8 +218,8 @@ document.addEventListener('DOMContentLoaded', function() {
       },
       anonymous: true,
       onload: function(response) {
-        var parser = new DOMParser();
-        var newDocument = parser.parseFromString(response.responseText,'text/html');
+        let parser = new DOMParser();
+        let newDocument = parser.parseFromString(response.responseText,'text/html');
         if (newDocument.getElementsByClassName('article__content')[0]) {
           document.open();
           document.write(newDocument.getElementsByTagName('html')[0].innerHTML);
@@ -237,6 +227,16 @@ document.addEventListener('DOMContentLoaded', function() {
         }
       }
     });
+    
+    const cookies = ['FTConsent=false', 'FTCookieConsentGDPR=true'];
+    document.cookie = cookies[0];
+    document.cookie = cookies[1];
+    localStorage.clear();
+    sessionStorage.clear();
+    indexedDB.deleteDatabase('next-flags');
+    indexedDB.deleteDatabase('next:ads');
+    eraseAllCookiesExcept(cookies);
+    document.querySelector('.o-banner').remove();
   }
 
   else if (/foreignpolicy\.com/.test(document.location.host)) {
@@ -458,48 +458,38 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 });
 
-function eraseAllCookies() {
-  var cookieList  = document.cookie.split (/;\s*/);
-  for (var J = cookieList.length - 1;   J >= 0;  --J) {
-    var cookieName = cookieList[J].replace (/\s*(\w+)=.+$/, '$1');
-    eraseCookie (cookieName);
+// Helper functions
+function eraseCookie (cookieName) {
+  try {
+    document.cookie = cookieName + '=;expires=Thu, 01 Jan 1970 00:00:00 UTC';
+  } catch (error) {
+    console.error(`Could not erase cookie ${cookieName}. Error:` + error.message);
   }
 }
 
-function eraseCookie (cookieName) {
-  // https://stackoverflow.com/a/28081337/1840019
-  //--- ONE-TIME INITS:
-  //--- Set possible domains. Omits some rare edge cases.?.
-  var domain      = document.domain;
-  var domain2     = document.domain.replace (/^www\./, '');
-  var domain3     = document.domain.replace (/^(\w+\.)+?(\w+\.\w+)$/, '$2');
+function eraseAllCookies() {
+  let cookies = document.cookie.split(';');
 
-  //--- Get possible paths for the current page:
-  var pathNodes   = location.pathname.split ('/').map ( function (pathWord) {
-    return '/' + pathWord;
-  } );
-  var cookPaths   = [''].concat (pathNodes.map ( function (pathNode) {
-    if (this.pathStr) {
-      this.pathStr += pathNode;
-    }
-    else {
-      this.pathStr = '; path=';
-      return (this.pathStr + pathNode);
-    }
-    return (this.pathStr);
-  } ) );
-
-  // eslint-disable-next-line no-func-assign
-  ( eraseCookie = function (cookieName) {
-    //--- For each path, attempt to delete the cookie.
-    cookPaths.forEach ( function (pathStr) {
-      //--- To delete a cookie, set its expiration date to a past value.
-      var diagStr     = cookieName + '=' + pathStr + '; expires=Thu, 01-Jan-1970 00:00:01 GMT;';
-      document.cookie = diagStr;
-
-      document.cookie = cookieName + '=' + pathStr + '; domain=' + domain  + '; expires=Thu, 01-Jan-1970 00:00:01 GMT;';
-      document.cookie = cookieName + '=' + pathStr + '; domain=' + domain2 + '; expires=Thu, 01-Jan-1970 00:00:01 GMT;';
-      document.cookie = cookieName + '=' + pathStr + '; domain=' + domain3 + '; expires=Thu, 01-Jan-1970 00:00:01 GMT;';
-    } );
-  } ) (cookieName);
+  for (let i = 0; i < cookies.length; i++) {
+    let cookie = cookies[i];
+    let eqPos = cookie.indexOf('=');
+    let cookieName = eqPos > -1 ? cookie.substring(0, eqPos) : cookie;
+    eraseCookie(cookieName);
+  }
 }
+
+// receives an array of cookies names as argument
+function eraseAllCookiesExcept(cookieArray) {
+  let cookies = document.cookie.split(';');
+
+  for (let i = 0; i < cookies.length; i++) {
+    let cookie = cookies[i];
+    let eqPos = cookie.indexOf('=');
+    let cookieName = eqPos > -1 ? cookie.substring(0, eqPos) : cookie;
+    
+    if (!cookieArray.includes(cookieName)) {
+      eraseCookie(cookieName);
+    }
+  }
+}
+/* eslint max-len: "off" */


### PR DESCRIPTION
Esse PR corrige o site do Finacial Times que estava "mais ou menos funcionando". Mais ou menos pq era preciso dar um refresh na página depois de ser bloqueado. Isso pq o script estava apagando os cookies e localStorage antes da página setar os valores iniciais.

Eu precisei criar uma função extra (`eraseAllCookiesExcept`) para apagar todos os cookies com a exceção de 2 que eram necessários para fazer sumir um maldito modal que perguntava sobre as opções de cookies sumir (não consegui sumir com esse modal de nenhuma outra forma...).

Como utilizei as funções antigas nessa função nova, acabei refatorando as outras duas funções `eraseAllCookies` e `eraseCookie`. Acho que está muito mais fácil de entender o que elas fazem agora. Se preferir, eu faço um PR separado para elas...

Não sei se o problema que eu estava tendo no site era o mesmo dessa issue #12, que é bem antiga, mas achei que dava pra fechá-la mesmo assim.

Uma última coisa: acabei desligando a regra de tamanho máximo da linha do eslint, uma vez que tinham vários warnings e pelo jeito, vcs não fazem questão que essa regra seja seguida. Então, achei melhor desligar para sumir com os warnings.
